### PR TITLE
Would you go back to the ruby convention?

### DIFF
--- a/snippets/eruby.snippets
+++ b/snippets/eruby.snippets
@@ -4,7 +4,7 @@
 
 # Rails *****************************
 snippet rc
-	<% ${1} -%>
+	<% ${1} -%>${2}
 snippet rce
 	<%= ${1} %>${2}
 snippet end
@@ -14,23 +14,23 @@ snippet for
 		${3}
 	<% end %>
 snippet rp
-	<%= render :partial => '${1:item}' %>
+	<%= render partial: '${1:item}' %>
 snippet rpl
-	<%= render :partial => '${1:item}', :locals => { :${2:name} => '${3:value}'$4 } %>
+	<%= render partial: '${1:item}', locals: { :${2:name} => '${3:value}'$4 } %>
 snippet rps
-	<%= render :partial => '${1:item}', :status => ${2:500} %>
+	<%= render partial: '${1:item}', status: ${2:500} %>
 snippet rpc
-	<%= render :partial => '${1:item}', :collection => ${2:items} %>
+	<%= render partial: '${1:item}', collection: ${2:items} %>
 snippet lia
-	<%= link_to '${1:link text...}', :action => '${2:index}' %>
+	<%= link_to '${1:link text...}', action: '${2:index}' %>
 snippet liai
-	<%= link_to '${1:link text...}', :action => '${2:edit}', :id => ${3:@item} %>
+	<%= link_to '${1:link text...}', action: '${2:edit}', :id => ${3:@item} %>
 snippet lic
-	<%= link_to '${1:link text...}', :controller => '${2:items}' %>
+	<%= link_to '${1:link text...}', controller: '${2:items}' %>
 snippet lica
-	<%= link_to '${1:link text...}', :controller => '${2:items}', :action => '${3:index}' %>
+	<%= link_to '${1:link text...}', controller: '${2:items}', action: '${3:index}' %>
 snippet licai
-	<%= link_to '${1:link text...}', :controller => '${2:items}', :action => '${3:edit}', :id => ${4:@item} %>
+	<%= link_to '${1:link text...}', controller: '${2:items}', action: '${3:edit}', id: ${4:@item} %>
 snippet yield
 	<%= yield${1::content_symbol}%>${2}
 snippet conf

--- a/snippets/eruby.snippets
+++ b/snippets/eruby.snippets
@@ -24,7 +24,7 @@ snippet rpc
 snippet lia
 	<%= link_to '${1:link text...}', action: '${2:index}' %>
 snippet liai
-	<%= link_to '${1:link text...}', action: '${2:edit}', :id => ${3:@item} %>
+	<%= link_to '${1:link text...}', action: '${2:edit}', id: ${3:@item} %>
 snippet lic
 	<%= link_to '${1:link text...}', controller: '${2:items}' %>
 snippet lica


### PR DESCRIPTION
in ruby 1.9+ convention for `=>` rocket hash,  have replacing with `foo:`

:)
